### PR TITLE
fixed division by zero bug

### DIFF
--- a/j3d-loaders/src/main/java/org/j3d/loaders/c3d/C3DParser.java
+++ b/j3d-loaders/src/main/java/org/j3d/loaders/c3d/C3DParser.java
@@ -389,7 +389,9 @@ public class  C3DParser
         reader.setBuffer(buffer);
 
         // Readjust the read values to be more useful
-        header.numAnalogChannels /= header.numAnalogSamplesPer3DFrame;
+        if (header.numAnalogSamplesPer3DFrame != 0) {
+            header.numAnalogChannels /= header.numAnalogSamplesPer3DFrame;
+        } // on a C3D file without analog data this would divide by zero
         header.analogSampleRate = header.trajectorySampleRate *
                                   header.numAnalogSamplesPer3DFrame;
 


### PR DESCRIPTION
When parsing a C3D file containing no analog data, the edited line caused the following exception:

```
 Exception in thread "main" java.lang.ArithmeticException: / by zero
    at org.j3d.loaders.c3d.C3DParser.parseHeader(C3DParser.java:392)
```
